### PR TITLE
Rename format in rawaudio format and other breaking changes | MS-37

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -157,9 +157,10 @@
         #
         # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
         #
-        {Credo.Check.Readability.StrictModuleLayout, priority: :normal},
+        {Credo.Check.Readability.StrictModuleLayout,
+         priority: :normal, order: ~w/shortdoc moduledoc behaviour use import require alias/a},
         {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
-        {Credo.Check.Consistency.UnusedVariableNames, []},
+        {Credo.Check.Consistency.UnusedVariableNames, force: :meaningful},
         {Credo.Check.Design.DuplicatedCode, false},
         {Credo.Check.Readability.AliasAs, false},
         {Credo.Check.Readability.MultiAlias, false},

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![CircleCI](https://circleci.com/gh/membraneframework/membrane_raw_audio_format/tree/master.svg?style=svg)](https://circleci.com/gh/membraneframework/membrane_raw_audio_format/tree/master)
 
 
-This package provides raw audio format definition (so-called caps) for the
-[Membrane Multimedia Framework](https://membraneframework.org).
+This package provides raw audio format definition for the [Membrane Multimedia Framework](https://membraneframework.org).
 
 Beyond general data structures it contains some useful helper functions for
 manipulating raw audio samples.

--- a/lib/membrane_raw_audio.ex
+++ b/lib/membrane_raw_audio.ex
@@ -43,9 +43,8 @@ defmodule Membrane.RawAudio do
           sample_format: SampleFormat.t()
         }
 
-  defstruct channels: nil,
-            sample_rate: nil,
-            sample_format: nil
+  @enforce_keys [:channels, :sample_rate, :sample_format]
+  defstruct @enforce_keys
 
   @doc """
   Returns how many bytes are needed to store a single sample.

--- a/lib/membrane_raw_audio.ex
+++ b/lib/membrane_raw_audio.ex
@@ -53,7 +53,7 @@ defmodule Membrane.RawAudio do
   """
   @spec sample_size(t) :: integer
   def sample_size(%__MODULE__{sample_format: format}) do
-    {_, size, _} = SampleFormat.to_tuple(format)
+    {_type, size, _endianness} = SampleFormat.to_tuple(format)
     size |> div(8)
   end
 
@@ -75,8 +75,8 @@ defmodule Membrane.RawAudio do
   @spec sample_type_float?(t) :: boolean
   def sample_type_float?(%__MODULE__{sample_format: format}) do
     case SampleFormat.to_tuple(format) do
-      {:f, _, _} -> true
-      _ -> false
+      {:f, _size, _endianness} -> true
+      _otherwise -> false
     end
   end
 
@@ -88,9 +88,9 @@ defmodule Membrane.RawAudio do
   @spec sample_type_fixed?(t) :: boolean
   def sample_type_fixed?(%__MODULE__{sample_format: format}) do
     case SampleFormat.to_tuple(format) do
-      {:s, _, _} -> true
-      {:u, _, _} -> true
-      _ -> false
+      {:s, _size, _endianness} -> true
+      {:u, _size, _endianness} -> true
+      _otherwise -> false
     end
   end
 
@@ -102,9 +102,9 @@ defmodule Membrane.RawAudio do
   @spec little_endian?(t) :: boolean
   def little_endian?(%__MODULE__{sample_format: format}) do
     case SampleFormat.to_tuple(format) do
-      {_, _, :le} -> true
-      {_, _, :any} -> true
-      _ -> false
+      {_type, _size, :le} -> true
+      {_type, _size, :any} -> true
+      _otherwise -> false
     end
   end
 
@@ -116,9 +116,9 @@ defmodule Membrane.RawAudio do
   @spec big_endian?(t) :: boolean
   def big_endian?(%__MODULE__{sample_format: format}) do
     case SampleFormat.to_tuple(format) do
-      {_, _, :be} -> true
-      {_, _, :any} -> true
-      _ -> false
+      {_type, _size, :be} -> true
+      {_type, _size, :any} -> true
+      _otherwise -> false
     end
   end
 
@@ -130,9 +130,9 @@ defmodule Membrane.RawAudio do
   @spec signed?(t) :: boolean
   def signed?(%__MODULE__{sample_format: format}) do
     case SampleFormat.to_tuple(format) do
-      {:s, _, _} -> true
-      {:f, _, _} -> true
-      _ -> false
+      {:s, _size, _endianness} -> true
+      {:f, _size, _endianness} -> true
+      _otherwise -> false
     end
   end
 
@@ -144,8 +144,8 @@ defmodule Membrane.RawAudio do
   @spec unsigned?(t) :: boolean
   def unsigned?(%__MODULE__{sample_format: format}) do
     case SampleFormat.to_tuple(format) do
-      {:u, _, _} -> true
-      _ -> false
+      {:u, _size, _endianness} -> true
+      _otherwise -> false
     end
   end
 
@@ -236,9 +236,9 @@ defmodule Membrane.RawAudio do
     use Bitwise
 
     case SampleFormat.to_tuple(format) do
-      {:u, _, _} -> 0
-      {:s, size, _} -> -(1 <<< (size - 1))
-      {:f, _, _} -> -1.0
+      {:u, _size, _endianness} -> 0
+      {:s, size, _endianness} -> -(1 <<< (size - 1))
+      {:f, _size, _endianness} -> -1.0
     end
   end
 
@@ -252,9 +252,9 @@ defmodule Membrane.RawAudio do
     use Bitwise
 
     case SampleFormat.to_tuple(format) do
-      {:s, size, _} -> (1 <<< (size - 1)) - 1
-      {:u, size, _} -> (1 <<< size) - 1
-      {:f, _, _} -> 1.0
+      {:s, size, _endianness} -> (1 <<< (size - 1)) - 1
+      {:u, size, _endianness} -> (1 <<< size) - 1
+      {:f, _size, _endianness} -> 1.0
     end
   end
 

--- a/lib/membrane_raw_audio.ex
+++ b/lib/membrane_raw_audio.ex
@@ -1,7 +1,7 @@
 defmodule Membrane.RawAudio do
   @moduledoc """
-  This module implements struct (`t:#{inspect(__MODULE__)}.t/0`)
-  for caps representing raw audio stream with interleaved channels.
+  This module contains a definition and related functions for struct `t:#{inspect(__MODULE__)}.t/0`,
+  describing a format of raw audio stream with interleaved channels.
   """
 
   alias __MODULE__.SampleFormat
@@ -63,12 +63,12 @@ defmodule Membrane.RawAudio do
   Inlined by the compiler
   """
   @spec frame_size(t) :: integer
-  def frame_size(%__MODULE__{channels: channels} = caps) do
-    sample_size(caps) * channels
+  def frame_size(%__MODULE__{channels: channels} = format) do
+    sample_size(format) * channels
   end
 
   @doc """
-  Determines if sample format is floating point.
+  Determines if the sample values are represented by a floating point number.
 
   Inlined by the compiler.
   """
@@ -81,7 +81,7 @@ defmodule Membrane.RawAudio do
   end
 
   @doc """
-  Determines if sample format is integer.
+  Determines if the sample values are represented by an integer.
 
   Inlined by the compiler.
   """
@@ -95,7 +95,7 @@ defmodule Membrane.RawAudio do
   end
 
   @doc """
-  Determines if sample format is little endian.
+  Determines if the sample values are represented by a number in little endian byte ordering.
 
   Inlined by the compiler.
   """
@@ -109,7 +109,7 @@ defmodule Membrane.RawAudio do
   end
 
   @doc """
-  Determines if sample format is big endian.
+  Determines if the sample values are represented by a number in big endian byte ordering.
 
   Inlined by the compiler.
   """
@@ -123,7 +123,7 @@ defmodule Membrane.RawAudio do
   end
 
   @doc """
-  Determines if sample format is signed.
+  Determines if the sample values are represented by a signed number.
 
   Inlined by the compiler.
   """
@@ -137,7 +137,7 @@ defmodule Membrane.RawAudio do
   end
 
   @doc """
-  Determines if sample format is unsigned.
+  Determines if the sample values are represented by an unsigned number.
 
   Inlined by the compiler.
   """
@@ -218,9 +218,9 @@ defmodule Membrane.RawAudio do
   Inlined by the compiler.
   """
   @spec value_to_sample_check_overflow(number, t) :: {:ok, binary} | {:error, :overflow}
-  def value_to_sample_check_overflow(value, caps) do
-    if sample_min(caps) <= value and sample_max(caps) >= value do
-      {:ok, value_to_sample(value, caps)}
+  def value_to_sample_check_overflow(value, format) do
+    if sample_min(format) <= value and sample_max(format) >= value do
+      {:ok, value_to_sample(value, format)}
     else
       {:error, :overflow}
     end
@@ -259,7 +259,7 @@ defmodule Membrane.RawAudio do
   end
 
   @doc """
-  Returns one 'silent' sample, that is value of zero in given caps' sample format.
+  Returns one 'silent' sample, that is value of zero in given format' sample format.
 
   Inlined by the compiler.
   """
@@ -285,84 +285,84 @@ defmodule Membrane.RawAudio do
 
   @doc """
   Returns a binary which corresponds to the silence during the given interval
-  of time in given caps' sample format
+  of time in given format' sample format
 
   ## Examples:
-  The following code generates the silence for the given caps
+  The following code generates the silence for the given format
 
-      iex> alias Membrane.RawAudio, as: Caps
-      iex> caps = %Caps{sample_rate: 48_000, sample_format: :s16le, channels: 2}
-      iex> silence = Caps.silence(caps, 100 |> Membrane.Time.microseconds)
+      iex> alias Membrane.RawAudio
+      iex> format = %RawAudio{sample_rate: 48_000, sample_format: :s16le, channels: 2}
+      iex> silence = RawAudio.silence(format, 100 |> Membrane.Time.microseconds())
       <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
   """
   @spec silence(t, Time.non_neg_t(), (float -> integer)) :: binary
-  def silence(%__MODULE__{} = caps, time, round_f \\ &(&1 |> :math.ceil() |> trunc))
+  def silence(%__MODULE__{} = format, time, round_f \\ &(&1 |> :math.ceil() |> trunc))
       when time >= 0 do
-    length = time_to_frames(time, caps, round_f)
-    silence(caps) |> String.duplicate(caps.channels * length)
+    length = time_to_frames(time, format, round_f)
+    silence(format) |> String.duplicate(format.channels * length)
   end
 
   @doc """
-  Converts frames to bytes in given caps.
+  Converts frames to bytes in given format.
 
   Inlined by the compiler.
   """
   @spec frames_to_bytes(non_neg_integer, t) :: non_neg_integer
-  def frames_to_bytes(frames, %__MODULE__{} = caps) when frames >= 0 do
-    frames * frame_size(caps)
+  def frames_to_bytes(frames, %__MODULE__{} = format) when frames >= 0 do
+    frames * frame_size(format)
   end
 
   @doc """
-  Converts bytes to frames in given caps.
+  Converts bytes to frames in given format.
 
   Inlined by the compiler.
   """
   @spec bytes_to_frames(non_neg_integer, t, (float -> integer)) :: non_neg_integer
-  def bytes_to_frames(bytes, %__MODULE__{} = caps, round_f \\ &trunc/1) when bytes >= 0 do
-    (bytes / frame_size(caps)) |> round_f.()
+  def bytes_to_frames(bytes, %__MODULE__{} = format, round_f \\ &trunc/1) when bytes >= 0 do
+    (bytes / frame_size(format)) |> round_f.()
   end
 
   @doc """
-  Converts time in Membrane.Time units to frames in given caps.
+  Converts time in Membrane.Time units to frames in given format.
 
   Inlined by the compiler.
   """
   @spec time_to_frames(Time.non_neg_t(), t, (float -> integer)) :: non_neg_integer
-  def time_to_frames(time, %__MODULE__{} = caps, round_f \\ &(&1 |> :math.ceil() |> trunc))
+  def time_to_frames(time, %__MODULE__{} = format, round_f \\ &(&1 |> :math.ceil() |> trunc))
       when time >= 0 do
-    (time * caps.sample_rate / Time.second()) |> round_f.()
+    (time * format.sample_rate / Time.second()) |> round_f.()
   end
 
   @doc """
-  Converts frames to time in Membrane.Time units in given caps.
+  Converts frames to time in Membrane.Time units in given format.
 
   Inlined by the compiler.
   """
   @spec frames_to_time(non_neg_integer, t, (float -> integer)) :: Time.non_neg_t()
-  def frames_to_time(frames, %__MODULE__{} = caps, round_f \\ &trunc/1)
+  def frames_to_time(frames, %__MODULE__{} = format, round_f \\ &trunc/1)
       when frames >= 0 do
-    (frames * Time.second() / caps.sample_rate) |> round_f.()
+    (frames * Time.second() / format.sample_rate) |> round_f.()
   end
 
   @doc """
-  Converts time in Membrane.Time units to bytes in given caps.
+  Converts time in Membrane.Time units to bytes in given format.
 
   Inlined by the compiler.
   """
   @spec time_to_bytes(Time.non_neg_t(), t, (float -> integer)) :: non_neg_integer
-  def time_to_bytes(time, %__MODULE__{} = caps, round_f \\ &(&1 |> :math.ceil() |> trunc))
+  def time_to_bytes(time, %__MODULE__{} = format, round_f \\ &(&1 |> :math.ceil() |> trunc))
       when time >= 0 do
-    time_to_frames(time, caps, round_f) |> frames_to_bytes(caps)
+    time_to_frames(time, format, round_f) |> frames_to_bytes(format)
   end
 
   @doc """
-  Converts bytes to time in Membrane.Time units in given caps.
+  Converts bytes to time in Membrane.Time units in given format.
 
   Inlined by the compiler.
   """
   @spec bytes_to_time(non_neg_integer, t, (float -> integer)) :: Time.non_neg_t()
-  def bytes_to_time(bytes, %__MODULE__{} = caps, round_f \\ &trunc/1)
+  def bytes_to_time(bytes, %__MODULE__{} = format, round_f \\ &trunc/1)
       when bytes >= 0 do
-    frames_to_time(bytes |> bytes_to_frames(caps), caps, round_f)
+    frames_to_time(bytes |> bytes_to_frames(format), format, round_f)
   end
 end

--- a/lib/membrane_raw_audio.ex
+++ b/lib/membrane_raw_audio.ex
@@ -233,7 +233,7 @@ defmodule Membrane.RawAudio do
   """
   @spec sample_min(t) :: number
   def sample_min(%__MODULE__{sample_format: format}) do
-    use Bitwise
+    import Bitwise
 
     case SampleFormat.to_tuple(format) do
       {:u, _size, _endianness} -> 0
@@ -249,7 +249,7 @@ defmodule Membrane.RawAudio do
   """
   @spec sample_max(t) :: number
   def sample_max(%__MODULE__{sample_format: format}) do
-    use Bitwise
+    import Bitwise
 
     case SampleFormat.to_tuple(format) do
       {:s, size, _endianness} -> (1 <<< (size - 1)) - 1

--- a/lib/membrane_raw_audio/sample_format.ex
+++ b/lib/membrane_raw_audio/sample_format.ex
@@ -4,8 +4,8 @@ defmodule Membrane.RawAudio.SampleFormat do
   and some helpers to deal with them.
   """
 
-  use Bitwise
   use Bunch.Typespec
+  import Bitwise
 
   @compile {:inline,
             [

--- a/lib/membrane_raw_audio/sample_format.ex
+++ b/lib/membrane_raw_audio/sample_format.ex
@@ -1,6 +1,6 @@
-defmodule Membrane.RawAudio.Format do
+defmodule Membrane.RawAudio.SampleFormat do
   @moduledoc """
-  This module defines formats used in `Membrane.RawAudio`
+  This module defines sample formats used in `Membrane.RawAudio`
   and some helpers to deal with them.
   """
 

--- a/lib/membrane_raw_audio/sample_format.ex
+++ b/lib/membrane_raw_audio/sample_format.ex
@@ -90,10 +90,10 @@ defmodule Membrane.RawAudio.SampleFormat do
   # Serialization constants
 
   @sample_types BiMap.new(s: 0b01 <<< 30, u: 0b00 <<< 30, f: 0b11 <<< 30)
-  @sample_endiannesses BiMap.new(le: 0b0 <<< 29, be: 0b1 <<< 29)
+  @endianness_mapping BiMap.new(le: 0b0 <<< 29, be: 0b1 <<< 29)
 
   @sample_type 0b11 <<< 30
-  @sample_endianness 0b1 <<< 29
+  @endianness_bitmask 0b1 <<< 29
   @sample_size (0b1 <<< 8) - 1
 
   @doc """
@@ -112,7 +112,7 @@ defmodule Membrane.RawAudio.SampleFormat do
   def serialize(format) do
     {type, size, endianness} = format |> to_tuple
 
-    0 ||| @sample_types[type] ||| (@sample_endiannesses[endianness] || @sample_endiannesses[:le]) |||
+    0 ||| @sample_types[type] ||| (@endianness_mapping[endianness] || @endianness_mapping[:le]) |||
       size
   end
 
@@ -138,7 +138,7 @@ defmodule Membrane.RawAudio.SampleFormat do
           :any
 
         _otherwise ->
-          @sample_endiannesses |> BiMap.get_key(serialized_format &&& @sample_endianness)
+          @endianness_mapping |> BiMap.get_key(serialized_format &&& @endianness_bitmask)
       end
 
     {type, size, endianness} |> from_tuple

--- a/lib/membrane_raw_audio/sample_format.ex
+++ b/lib/membrane_raw_audio/sample_format.ex
@@ -134,8 +134,11 @@ defmodule Membrane.RawAudio.SampleFormat do
 
     endianness =
       case size do
-        8 -> :any
-        _ -> @sample_endiannesses |> BiMap.get_key(serialized_format &&& @sample_endianness)
+        8 ->
+          :any
+
+        _otherwise ->
+          @sample_endiannesses |> BiMap.get_key(serialized_format &&& @sample_endianness)
       end
 
     {type, size, endianness} |> from_tuple

--- a/test/membrane_raw_audio/sample_format_test.exs
+++ b/test/membrane_raw_audio/sample_format_test.exs
@@ -1,7 +1,7 @@
-defmodule Membrane.RawAudio.FormatTest do
+defmodule Membrane.RawAudio.SampleFormatTest do
   use ExUnit.Case, async: true
 
-  alias Membrane.RawAudio.Format
+  alias Membrane.RawAudio.SampleFormat
 
   @all_formats [
     :s8,
@@ -48,21 +48,21 @@ defmodule Membrane.RawAudio.FormatTest do
   test "to_tuple/1" do
     Enum.zip(@all_formats, @all_tuples)
     |> Enum.each(fn {fmt, tuple} ->
-      assert Format.to_tuple(fmt) == tuple
+      assert SampleFormat.to_tuple(fmt) == tuple
     end)
   end
 
   test "from_tuple/1" do
     Enum.zip(@all_tuples, @all_formats)
     |> Enum.each(fn {tuple, fmt} ->
-      assert Format.from_tuple(tuple) == fmt
+      assert SampleFormat.from_tuple(tuple) == fmt
     end)
   end
 
   test "Using serialize/1 and then deserialize/1" do
     @all_formats
     |> Enum.each(fn fmt ->
-      assert fmt |> Format.serialize() |> Format.deserialize() == fmt
+      assert fmt |> SampleFormat.serialize() |> SampleFormat.deserialize() == fmt
     end)
   end
 end

--- a/test/membrane_raw_audio_test.exs
+++ b/test/membrane_raw_audio_test.exs
@@ -2,7 +2,7 @@ defmodule Membrane.RawAudioTest do
   use ExUnit.Case, async: true
   alias Membrane.RawAudio
 
-  @all_formats [
+  @all_sample_formats [
     :s8,
     :u8,
     :s16le,
@@ -23,17 +23,17 @@ defmodule Membrane.RawAudioTest do
     :f64be
   ]
 
-  defp format_to_caps(format) do
-    %RawAudio{format: format, channels: 2, sample_rate: 44_100}
+  defp sample_format_to_caps(format) do
+    %RawAudio{sample_format: format, channels: 2, sample_rate: 44_100}
   end
 
   test "sample_size/1" do
     sizes = [1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 8, 8]
 
-    assert length(@all_formats) == length(sizes)
+    assert length(@all_sample_formats) == length(sizes)
 
-    @all_formats
-    |> Enum.map(&format_to_caps/1)
+    @all_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.zip(sizes)
     |> Enum.each(fn {caps, size} ->
       assert RawAudio.sample_size(caps) == size
@@ -43,17 +43,17 @@ defmodule Membrane.RawAudioTest do
   test "frame_size/1" do
     sizes = [2, 2, 4, 4, 4, 4, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 16, 16]
 
-    assert length(@all_formats) == length(sizes)
+    assert length(@all_sample_formats) == length(sizes)
 
-    @all_formats
-    |> Enum.map(&format_to_caps/1)
+    @all_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.zip(sizes)
     |> Enum.each(fn {caps, size} ->
       assert RawAudio.frame_size(caps) == size
     end)
   end
 
-  @float_formats [:f32be, :f32le, :f64le, :f64be]
+  @float_sample_formats [:f32be, :f32le, :f64le, :f64be]
 
   @non_float_caps [
     :s8,
@@ -73,23 +73,23 @@ defmodule Membrane.RawAudioTest do
   ]
 
   test "sample_type_float?" do
-    @float_formats
-    |> Enum.map(&format_to_caps/1)
+    @float_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> assert RawAudio.sample_type_float?(caps) == true end)
 
     @non_float_caps
-    |> Enum.map(&format_to_caps/1)
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> assert RawAudio.sample_type_float?(caps) == false end)
   end
 
-  test "sample_type_int?" do
-    @float_formats
-    |> Enum.map(&format_to_caps/1)
-    |> Enum.each(fn caps -> assert RawAudio.sample_type_int?(caps) == false end)
+  test "sample_type_fixed?" do
+    @float_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
+    |> Enum.each(fn caps -> assert RawAudio.sample_type_fixed?(caps) == false end)
 
     @non_float_caps
-    |> Enum.map(&format_to_caps/1)
-    |> Enum.each(fn caps -> assert RawAudio.sample_type_int?(caps) == true end)
+    |> Enum.map(&sample_format_to_caps/1)
+    |> Enum.each(fn caps -> assert RawAudio.sample_type_fixed?(caps) == true end)
   end
 
   @little_endian_caps [
@@ -118,33 +118,33 @@ defmodule Membrane.RawAudioTest do
 
   test "little_endian?" do
     @little_endian_caps
-    |> Enum.map(&format_to_caps/1)
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.little_endian?(caps) == true end)
 
     @big_endian_caps
-    |> Enum.map(&format_to_caps/1)
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.little_endian?(caps) == false end)
 
     @one_byte_caps
-    |> Enum.map(&format_to_caps/1)
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.little_endian?(caps) == true end)
   end
 
   test "big_endian?" do
     @little_endian_caps
-    |> Enum.map(&format_to_caps/1)
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.big_endian?(caps) == false end)
 
     @big_endian_caps
-    |> Enum.map(&format_to_caps/1)
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.big_endian?(caps) == true end)
 
     @one_byte_caps
-    |> Enum.map(&format_to_caps/1)
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.big_endian?(caps) == true end)
   end
 
-  @signed_formats [
+  @signed_sample_formats [
     :s8,
     :s16le,
     :s16be,
@@ -154,7 +154,7 @@ defmodule Membrane.RawAudioTest do
     :s32be
   ]
 
-  @unsigned_formats [
+  @unsigned_sample_formats [
     :u8,
     :u16le,
     :u16be,
@@ -165,36 +165,36 @@ defmodule Membrane.RawAudioTest do
   ]
 
   test "signed?" do
-    @signed_formats
-    |> Enum.map(&format_to_caps/1)
+    @signed_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.signed?(caps) == true end)
 
-    @unsigned_formats
-    |> Enum.map(&format_to_caps/1)
+    @unsigned_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.signed?(caps) == false end)
 
-    @float_formats
-    |> Enum.map(&format_to_caps/1)
+    @float_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.signed?(caps) == true end)
   end
 
   test "unsigned?/1" do
-    @signed_formats
-    |> Enum.map(&format_to_caps/1)
+    @signed_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.unsigned?(caps) == false end)
 
-    @unsigned_formats
-    |> Enum.map(&format_to_caps/1)
+    @unsigned_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.unsigned?(caps) == true end)
 
-    @float_formats
-    |> Enum.map(&format_to_caps/1)
+    @float_sample_formats
+    |> Enum.map(&sample_format_to_caps/1)
     |> Enum.each(fn caps -> RawAudio.unsigned?(caps) == false end)
   end
 
   @example_value 42
   defp assert_value_to_sample(format, result) do
-    assert RawAudio.value_to_sample(@example_value, format_to_caps(format)) == result
+    assert RawAudio.value_to_sample(@example_value, sample_format_to_caps(format)) == result
   end
 
   test "value_to_sample/2" do
@@ -218,7 +218,7 @@ defmodule Membrane.RawAudioTest do
   end
 
   defp assert_value_to_sample_check_overflow_ok(format, result) do
-    assert RawAudio.value_to_sample_check_overflow(@example_value, format_to_caps(format)) ==
+    assert RawAudio.value_to_sample_check_overflow(@example_value, sample_format_to_caps(format)) ==
              {:ok, result}
   end
 
@@ -243,7 +243,7 @@ defmodule Membrane.RawAudioTest do
   end
 
   defp assert_value_to_sample_check_overflow_error(value, format) do
-    assert RawAudio.value_to_sample_check_overflow(value, format_to_caps(format)) ==
+    assert RawAudio.value_to_sample_check_overflow(value, sample_format_to_caps(format)) ==
              {:error, :overflow}
   end
 
@@ -270,7 +270,7 @@ defmodule Membrane.RawAudioTest do
   end
 
   defp assert_sample_to_value_ok(sample, format, value) do
-    RawAudio.sample_to_value(sample, format |> format_to_caps) == {:ok, value}
+    RawAudio.sample_to_value(sample, format |> sample_format_to_caps) == {:ok, value}
   end
 
   test "sample_to_value/2" do
@@ -318,7 +318,7 @@ defmodule Membrane.RawAudioTest do
       {:f64be, -1.0}
     ]
     |> Enum.each(fn {format, min_sample} ->
-      assert RawAudio.sample_min(format |> format_to_caps()) == min_sample
+      assert RawAudio.sample_min(format |> sample_format_to_caps()) == min_sample
     end)
   end
 
@@ -340,7 +340,7 @@ defmodule Membrane.RawAudioTest do
       {:f64be, 1.0}
     ]
     |> Enum.each(fn {format, max_sample} ->
-      assert RawAudio.sample_max(format |> format_to_caps()) == max_sample
+      assert RawAudio.sample_max(format |> sample_format_to_caps()) == max_sample
     end)
   end
 end

--- a/test/membrane_raw_audio_test.exs
+++ b/test/membrane_raw_audio_test.exs
@@ -23,8 +23,8 @@ defmodule Membrane.RawAudioTest do
     :f64be
   ]
 
-  defp sample_format_to_caps(format) do
-    %RawAudio{sample_format: format, channels: 2, sample_rate: 44_100}
+  defp to_raw_audio_format(sample_format) when sample_format in @all_sample_formats do
+    %RawAudio{sample_format: sample_format, channels: 2, sample_rate: 44_100}
   end
 
   test "sample_size/1" do
@@ -33,10 +33,10 @@ defmodule Membrane.RawAudioTest do
     assert length(@all_sample_formats) == length(sizes)
 
     @all_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
+    |> Enum.map(&to_raw_audio_format/1)
     |> Enum.zip(sizes)
-    |> Enum.each(fn {caps, size} ->
-      assert RawAudio.sample_size(caps) == size
+    |> Enum.each(fn {sample_format, size} ->
+      assert RawAudio.sample_size(sample_format) == size
     end)
   end
 
@@ -46,16 +46,16 @@ defmodule Membrane.RawAudioTest do
     assert length(@all_sample_formats) == length(sizes)
 
     @all_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
+    |> Enum.map(&to_raw_audio_format/1)
     |> Enum.zip(sizes)
-    |> Enum.each(fn {caps, size} ->
-      assert RawAudio.frame_size(caps) == size
+    |> Enum.each(fn {sample_format, size} ->
+      assert RawAudio.frame_size(sample_format) == size
     end)
   end
 
   @float_sample_formats [:f32be, :f32le, :f64le, :f64be]
 
-  @non_float_caps [
+  @non_float_formats [
     :s8,
     :u8,
     :s16le,
@@ -74,25 +74,29 @@ defmodule Membrane.RawAudioTest do
 
   test "sample_type_float?" do
     @float_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> assert RawAudio.sample_type_float?(caps) == true end)
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> assert RawAudio.sample_type_float?(sample_format) == true end)
 
-    @non_float_caps
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> assert RawAudio.sample_type_float?(caps) == false end)
+    @non_float_formats
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format ->
+      assert RawAudio.sample_type_float?(sample_format) == false
+    end)
   end
 
   test "sample_type_fixed?" do
     @float_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> assert RawAudio.sample_type_fixed?(caps) == false end)
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format ->
+      assert RawAudio.sample_type_fixed?(sample_format) == false
+    end)
 
-    @non_float_caps
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> assert RawAudio.sample_type_fixed?(caps) == true end)
+    @non_float_formats
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> assert RawAudio.sample_type_fixed?(sample_format) == true end)
   end
 
-  @little_endian_caps [
+  @little_endian_sample_formats [
     :s16le,
     :u16le,
     :s24le,
@@ -103,7 +107,7 @@ defmodule Membrane.RawAudioTest do
     :f64le
   ]
 
-  @big_endian_caps [
+  @big_endian_sample_formats [
     :s16be,
     :u16be,
     :s24be,
@@ -114,34 +118,34 @@ defmodule Membrane.RawAudioTest do
     :f64be
   ]
 
-  @one_byte_caps [:s8, :u8]
+  @one_byte_sample_formats [:s8, :u8]
 
   test "little_endian?" do
-    @little_endian_caps
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.little_endian?(caps) == true end)
+    @little_endian_sample_formats
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.little_endian?(sample_format) == true end)
 
-    @big_endian_caps
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.little_endian?(caps) == false end)
+    @big_endian_sample_formats
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.little_endian?(sample_format) == false end)
 
-    @one_byte_caps
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.little_endian?(caps) == true end)
+    @one_byte_sample_formats
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.little_endian?(sample_format) == true end)
   end
 
   test "big_endian?" do
-    @little_endian_caps
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.big_endian?(caps) == false end)
+    @little_endian_sample_formats
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.big_endian?(sample_format) == false end)
 
-    @big_endian_caps
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.big_endian?(caps) == true end)
+    @big_endian_sample_formats
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.big_endian?(sample_format) == true end)
 
-    @one_byte_caps
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.big_endian?(caps) == true end)
+    @one_byte_sample_formats
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.big_endian?(sample_format) == true end)
   end
 
   @signed_sample_formats [
@@ -166,35 +170,36 @@ defmodule Membrane.RawAudioTest do
 
   test "signed?" do
     @signed_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.signed?(caps) == true end)
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.signed?(sample_format) == true end)
 
     @unsigned_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.signed?(caps) == false end)
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.signed?(sample_format) == false end)
 
     @float_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.signed?(caps) == true end)
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.signed?(sample_format) == true end)
   end
 
   test "unsigned?/1" do
     @signed_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.unsigned?(caps) == false end)
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.unsigned?(sample_format) == false end)
 
     @unsigned_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.unsigned?(caps) == true end)
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.unsigned?(sample_format) == true end)
 
     @float_sample_formats
-    |> Enum.map(&sample_format_to_caps/1)
-    |> Enum.each(fn caps -> RawAudio.unsigned?(caps) == false end)
+    |> Enum.map(&to_raw_audio_format/1)
+    |> Enum.each(fn sample_format -> RawAudio.unsigned?(sample_format) == false end)
   end
 
   @example_value 42
-  defp assert_value_to_sample(format, result) do
-    assert RawAudio.value_to_sample(@example_value, sample_format_to_caps(format)) == result
+  defp assert_value_to_sample(sample_format, result) do
+    assert RawAudio.value_to_sample(@example_value, to_raw_audio_format(sample_format)) ==
+             result
   end
 
   test "value_to_sample/2" do
@@ -217,8 +222,11 @@ defmodule Membrane.RawAudioTest do
     assert_value_to_sample(:u32be, <<0, 0, 0, @example_value>>)
   end
 
-  defp assert_value_to_sample_check_overflow_ok(format, result) do
-    assert RawAudio.value_to_sample_check_overflow(@example_value, sample_format_to_caps(format)) ==
+  defp assert_value_to_sample_check_overflow_ok(sample_format, result) do
+    assert RawAudio.value_to_sample_check_overflow(
+             @example_value,
+             to_raw_audio_format(sample_format)
+           ) ==
              {:ok, result}
   end
 
@@ -242,8 +250,11 @@ defmodule Membrane.RawAudioTest do
     assert_value_to_sample_check_overflow_ok(:u32be, <<0, 0, 0, @example_value>>)
   end
 
-  defp assert_value_to_sample_check_overflow_error(value, format) do
-    assert RawAudio.value_to_sample_check_overflow(value, sample_format_to_caps(format)) ==
+  defp assert_value_to_sample_check_overflow_error(value, sample_format) do
+    assert RawAudio.value_to_sample_check_overflow(
+             value,
+             to_raw_audio_format(sample_format)
+           ) ==
              {:error, :overflow}
   end
 
@@ -269,8 +280,8 @@ defmodule Membrane.RawAudioTest do
     assert_value_to_sample_check_overflow_error(-1, :u32be)
   end
 
-  defp assert_sample_to_value_ok(sample, format, value) do
-    RawAudio.sample_to_value(sample, format |> sample_format_to_caps) == {:ok, value}
+  defp assert_sample_to_value_ok(sample, sample_format, value) do
+    RawAudio.sample_to_value(sample, sample_format |> to_raw_audio_format()) == {:ok, value}
   end
 
   test "sample_to_value/2" do
@@ -317,8 +328,8 @@ defmodule Membrane.RawAudioTest do
       {:f64le, -1.0},
       {:f64be, -1.0}
     ]
-    |> Enum.each(fn {format, min_sample} ->
-      assert RawAudio.sample_min(format |> sample_format_to_caps()) == min_sample
+    |> Enum.each(fn {sample_format, min_sample} ->
+      assert RawAudio.sample_min(sample_format |> to_raw_audio_format()) == min_sample
     end)
   end
 
@@ -339,8 +350,8 @@ defmodule Membrane.RawAudioTest do
       {:f64le, 1.0},
       {:f64be, 1.0}
     ]
-    |> Enum.each(fn {format, max_sample} ->
-      assert RawAudio.sample_max(format |> sample_format_to_caps()) == max_sample
+    |> Enum.each(fn {sample_format, max_sample} ->
+      assert RawAudio.sample_max(sample_format |> to_raw_audio_format()) == max_sample
     end)
   end
 end


### PR DESCRIPTION
- closes #24 
- closes #16 
- Enforce `:sample_rate`, `:sample_format` and `:channels` keys in `Membrane.RawAudio.t()`