### PR TITLE
Add homepage link for hex docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Membrane.RawAudio.Mixfile do
 
   def project do
     [
+      homepage_url: "https://membrane.stream",
       app: :membrane_raw_audio_format,
       version: @version,
       elixir: "~> 1.12",


### PR DESCRIPTION
Solves https://github.com/membraneframework/membrane_core/issues/742